### PR TITLE
Add Phase 0 and Phase 1 implementation docs

### DIFF
--- a/docs/phases/00-foundation-and-tooling.md
+++ b/docs/phases/00-foundation-and-tooling.md
@@ -1,0 +1,275 @@
+# Phase 0: Foundation and Tooling
+
+**Tier:** 1 — Hardware Foundation
+**Duration:** 2 weeks
+**Deliverable:** Project scaffold, CI, `just build && just run`
+**Status:** Planned
+**Prerequisites:** None (first phase)
+**Unlocks:** Phase 1 (Boot and First Pixels)
+
+-----
+
+## Objective
+
+Set up a Rust bare-metal project targeting aarch64 that compiles a minimal kernel, runs it on QEMU, and outputs text to UART. Establish the build system, project structure, and CI pipeline that all subsequent phases build on.
+
+By the end of this phase, `just run` produces a QEMU window (or terminal) showing "AIOS kernel booting..." from a Rust `#![no_std]` binary running in EL1 on emulated aarch64 hardware.
+
+-----
+
+## Architecture References
+
+These existing documents define the technical design. This phase doc focuses on implementation order and acceptance criteria — not duplicating the architecture.
+
+| Topic | Document | Relevant Sections |
+|---|---|---|
+| Boot sequence | [boot.md](../kernel/boot.md) | §3.3 Steps 1-2 (FPU enable, VBAR install). boot.md §2 documents Phase 1's UEFI path; Phase 0 uses QEMU `-kernel` which bypasses UEFI entirely. |
+| HAL and platform trait | [hal.md](../kernel/hal.md) | §3 Platform Trait (`init_uart`, Uart trait). §2 Platform Detection (reading DTB compatible string, calling `detect_platform()`) is first exercised in Phase 1; Phase 0 hardcodes the QEMU UART. |
+| Memory layout | [memory.md](../kernel/memory.md) | §2 Physical Memory Manager, §2.1 Bootstrap (background only — explains the QEMU RAM base at `0x4000_0000` relevant to the load address decision; PMM implementation is Phase 2) |
+| Project overview | [overview.md](../project/overview.md) | §9 Hardware Strategy |
+| Technology stack | [development-plan.md](../project/development-plan.md) | §7 Technology Stack |
+
+-----
+
+## Milestones
+
+Phase 0 has three internal milestones. Each builds on the previous and produces something observable.
+
+| Milestone | Steps | Target | Observable result |
+|---|---|---|---|
+| **M1 — Compiles** | 1–2 | Days 2–3 | `cargo build` produces an aarch64 ELF with zero warnings |
+| **M2 — Boots** | 3–6 | End of week 1 | `just run` prints "AIOS kernel booting..." in terminal |
+| **M3 — Scaffold complete** | 7–8 | End of week 2 | CI passes on clean checkout; panic prints to UART; VBAR_EL1 confirmed |
+
+-----
+
+## Milestone 1 — Compiles (Days 2–3)
+
+*Goal: `cargo build` produces an aarch64 ELF with zero warnings.*
+
+-----
+
+### Step 1: Rust Toolchain and Target Setup
+
+**What:** Install and pin the Rust nightly toolchain with the `aarch64-unknown-none` target.
+
+**Tasks:**
+- [ ] Create `rust-toolchain.toml` pinning a specific nightly version
+- [ ] Add `aarch64-unknown-none` as the default target
+- [ ] Add components: `rust-src`, `llvm-tools`, `clippy`, `rustfmt`
+- [ ] Verify `cargo build --target aarch64-unknown-none` produces an empty binary
+
+**Note:** `aarch64-unknown-none` uses the hard-float ABI — the compiler emits NEON/FP instructions freely. This is correct for AIOS (needed for GGML/NEON in later phases) but requires enabling the FPU in boot assembly before any Rust code executes (see Step 3). The alternative `aarch64-unknown-none-softfloat` avoids the FPU constraint but is not used here because it cannot run NEON-optimized inference code.
+
+**Acceptance:** `rustup show` displays the pinned nightly with aarch64-unknown-none. `cargo build` succeeds (even if the binary does nothing).
+
+-----
+
+### Step 2: Project Scaffold and Cargo Workspace
+
+**What:** Create the workspace layout, project hygiene files, and crate structure that will grow across all 28 phases.
+
+**Tasks:**
+- [ ] Create root `Cargo.toml` as a workspace with `resolver = "2"` and `edition = "2021"`
+- [ ] Create `kernel/` crate — `#![no_std]`, `#![no_main]`, stub panic handler (`loop {}` — upgraded to UART output in Step 8 once UART exists)
+- [ ] Create `shared/` crate — `#![no_std]`, with the full `BootInfo` struct skeleton from boot.md §2.2 (all 12 fields). Use `Option<PhysAddr>` or `Option<u64>` stubs for fields that contain raw pointers in the final definition — raw `*const T` pointers make the struct non-`Send`/non-`Sync` and will fail to compile for the host target. Phase 1 will replace stubs with the real pointer types scoped behind `#[cfg(target_arch = "aarch64")]`. Phase 0 only populates `magic`; starting with the full field set avoids an ABI-breaking change at the Phase 0/1 boundary.
+- [ ] Verify `shared/` compiles with `--target aarch64-unknown-none` and with the host target (`cargo build` from workspace root)
+- [ ] Create `.cargo/config.toml` — set default target; use `build.rs` (not hardcoded `-T` in config.toml) to pass the linker script path, as config.toml paths are relative to the workspace root and break when building from subdirectories
+- [ ] Create `-C relocation-model=static` rustflag in `.cargo/config.toml` — correct for Phase 0's fixed load address. Note: KASLR (Phase 2) applies a random slide at boot-time on a static binary — it does not require switching to PIE. `relocation-model=static` remains correct beyond Phase 0.
+- [ ] Create `.gitignore` — ignore `target/`, QEMU disk images, editor files
+- [ ] Create `LICENSE` — BSD-2-Clause (per overview.md §1)
+- [ ] Create `README.md` — project name, one-line description, prerequisites (Rust nightly, QEMU 6.0+), build instructions (`just build && just run`)
+- [ ] Commit `Cargo.lock` — the kernel is a binary target; lock file ensures reproducible CI builds
+
+**Note:** All kernel crate dependencies must be `no_std` compatible with MIT or Apache-2.0 licenses, consistent with the BSD-2-Clause OS license policy.
+
+**Proposed layout:**
+```
+aios/
+├── Cargo.toml              (workspace root, resolver = "2")
+├── Cargo.lock              (committed for reproducibility)
+├── rust-toolchain.toml
+├── justfile
+├── LICENSE                 (BSD-2-Clause)
+├── README.md
+├── .gitignore
+├── .cargo/
+│   └── config.toml         (target defaults, relocation-model=static)
+├── kernel/
+│   ├── Cargo.toml
+│   ├── build.rs            (emits cargo:rustc-link-arg=-T<linker script path>)
+│   └── src/
+│       ├── main.rs         (kernel_main, panic handler stub)
+│       └── arch/
+│           └── aarch64/
+│               ├── mod.rs
+│               ├── boot.S  (assembly entry point)
+│               ├── uart.rs (PL011 driver — added in Step 4)
+│               ├── exceptions.rs (vector table — added in Step 8)
+│               └── linker.ld
+├── shared/
+│   ├── Cargo.toml
+│   └── src/
+│       └── lib.rs          (#![no_std], full BootInfo skeleton)
+└── docs/                   (existing)
+```
+
+**Acceptance:** `cargo build` compiles both crates with zero warnings. `file` on the kernel ELF shows "ELF 64-bit LSB executable, ARM aarch64". `shared/` compiles for both `aarch64-unknown-none` and the host target with zero warnings.
+
+-----
+
+## Milestone 2 — Boots (End of Week 1)
+
+*Goal: `just run` prints "AIOS kernel booting..." in the terminal.*
+
+-----
+
+### Step 3: Linker Script and Assembly Entry Point
+
+**What:** Write the linker script that places kernel sections at the correct addresses for QEMU virt machine, and the assembly stub that initializes the CPU state and jumps to Rust.
+
+**EL and MMU note:** QEMU `-kernel` on the virt machine boots directly to EL1 with MMU off and caches off. There is no EL2 setup in Phase 0's boot assembly — QEMU handles the EL transition (see boot.md §2.6: "the kernel never touches EL2 registers"). Note that boot.md §3.3 Step 1 describes the UEFI handoff path where "MMU is on, caches are on" — that does not apply here. Phase 0's boot assembly runs with MMU off throughout; the load address `0x4008_0000` is a physical address, and MMIO access (e.g. UART at `0x0900_0000`) works correctly at EL1 with MMU off.
+
+**Linker script tasks:**
+- [ ] Create `kernel/src/arch/aarch64/linker.ld`
+- [ ] Set `.text` origin at `0x4008_0000` (512 KiB above QEMU virt RAM base at `0x4000_0000` — leaves room for the DTB QEMU typically places near RAM start; the actual DTB address is passed in `x0` at entry and may vary, see Decision Points)
+- [ ] Define sections in order: `.text`, `.rodata`, `.data`, `.bss`, stack region
+- [ ] Export `__bss_start` and `__bss_end` symbols (used by boot.S for BSS zeroing)
+- [ ] Place stub exception vector table in `.text.vectors` with `ALIGN(2048)` in the linker script — this aligns the section base to 2048 bytes as required by `VBAR_EL1`. Within the assembly file, each of the 16 individual 128-byte entries separately requires `.align 7` (2^7 = 128 bytes) to ensure correct 128-byte slot alignment within the section. Both are needed: the linker script aligns the section base; the assembly aligns each slot within it.
+- [ ] Emit the linker script path via `build.rs` with `println!("cargo:rustc-link-arg=-T{}", ...)`
+
+**Assembly entry point tasks (`boot.S`):**
+
+The boot sequence must follow this exact order. The ordering is strict — FPU must be enabled before any Rust-generated code runs:
+
+- [ ] **1. Enable FP/NEON (must be first):** Use any available scratch register. Example using `x1`: `mrs x1, CPACR_EL1; orr x1, x1, #(3 << 20); msr CPACR_EL1, x1; isb`. This matches boot.md §3.3 which also uses `x1`. The hard-float ABI means the compiler emits NEON instructions for `memcpy`/`memset` — including during BSS zeroing. Any NEON instruction before this traps. **Boot protocol note:** QEMU `-kernel` passes a DTB physical address in `x0` per the Linux arm64 boot protocol (Phase 0 discards it after this step). Phase 1 switches to UEFI boot, which passes the `BootInfo` pointer in `x0`; that pointer is preserved in a callee-saved register (e.g. `x19`) for later use by kernel initialization. Preserving `x0` in Phase 0 is unnecessary but harmless if preferred for consistency with Phase 1.
+- [ ] **2. Install stub exception vectors:** Write address of the vector table to `VBAR_EL1`. Stub entries branch-to-self (`b .`) so any early fault halts deterministically instead of jumping to garbage memory. This is a temporary safety net — replaced with the Rust-defined table in Step 8.
+- [ ] **3. Park secondary cores:** Read `MPIDR_EL1`, extract core ID (Aff0 field). If not core 0, enter `wfe` loop. `wfe` (Wait For Event) is preferred over `wfi` because the boot CPU can wake all parked secondaries simultaneously with a single `sev` (Send Event) broadcast — no GIC configuration required. `wfi` can also be woken (by any pending interrupt, even masked ones), but waking secondaries that way requires the GIC to be configured to deliver an IPI to each core, which is Phase 1+ work.
+- [ ] **4. Set stack pointer:** Load stack top address from linker-script-defined symbol.
+- [ ] **5. Zero BSS:** Loop from `__bss_start` to `__bss_end` using `str xzr` (safe now that FPU is enabled in step 1).
+- [ ] **6. Branch to `kernel_main`:** The Rust entry point must be declared `#[no_mangle] pub extern "C" fn kernel_main() -> !` — without `#[no_mangle]`, the linker cannot find the symbol and will error.
+
+**QEMU boot protocol note:** QEMU `-kernel` loads the ELF at the physical address matching the ELF's load segment (`0x4008_0000` per the linker script — with MMU off, physical and virtual addresses are the same). QEMU generates a DTB and passes its physical address in `x0` following the Linux arm64 boot protocol. Phase 0 discards `x0` after the FPU enable sequence.
+
+**Acceptance:** `cargo objdump -- -d` shows `kernel_main` near `0x4008_0000`. `cargo objdump -- -h` shows `.text` at `0x4008_0000`, `.bss` after `.data`, no overlapping sections. Vector table section is 2048-byte aligned.
+
+**Key reference:** [boot.md](../kernel/boot.md) §3.3 Steps 1-2 document the FPU enable and VBAR install sequence. Phase 0 implements a subset of this; the full UEFI handoff and `BootInfo` assembly is Phase 1 work.
+
+-----
+
+### Step 4: UART Output (PL011)
+
+**What:** Implement minimal PL011 UART driver so the kernel can print text. This is the first HAL device.
+
+**Tasks:**
+- [ ] Create `kernel/src/arch/aarch64/uart.rs` — PL011 at QEMU virt UART0 base (`0x0900_0000`)
+- [ ] Implement `putc(byte: u8)` — spin on TXFF flag in UARTFR (offset `0x018`), write to UARTDR (offset `0x000`)
+- [ ] Implement `print!` / `println!` macros wrapping UART output
+- [ ] Call `println!("AIOS kernel booting...")` from `kernel_main`
+
+**QEMU init note:** On QEMU virt, the PL011 is pre-initialized by QEMU — writing to UARTDR after checking TXFF is sufficient without configuring baud rate registers (IBRD, FBRD, LCR_H, CR). Do not write the full PL011 init sequence for Phase 0; it is unnecessary and QEMU's pre-init values will be overwritten. On real hardware (Phase 5+), full PL011 initialization is required.
+
+**Debug note:** If UART output does not appear, the failure is more likely in Step 3 (wrong load address, missing FPU enable, BSS not zeroed, `kernel_main` not found by linker) than in the UART driver itself. Verify the entry point address with `cargo objdump -- -d` and confirm the binary loads at `0x4008_0000` before investigating UART registers. Use `-d in_asm` in the QEMU invocation to trace executed instructions.
+
+**Key reference:** [hal.md](../kernel/hal.md) §3 defines the `Platform` trait and `init_uart` method. Phase 0 implements a hardcoded QEMU-only UART; the trait abstraction comes in Phase 1.
+
+**Acceptance:** Running in QEMU shows "AIOS kernel booting..." on serial output.
+
+-----
+
+### Step 5: Justfile (Build System)
+
+**What:** Create the `justfile` with recipes that will be used throughout all phases.
+
+**Tasks:**
+- [ ] `just build` — compile kernel in debug mode
+- [ ] `just build-release` — compile kernel in release mode
+- [ ] `just run` — build + launch QEMU (see Step 6 for full invocation)
+- [ ] `just debug` — build + launch QEMU with `-gdb tcp::1234 -S` (explicit port; do not use `-s` shorthand as behavior varies across QEMU versions)
+- [ ] `just test` — run `cargo test` on host (for unit tests that don't need QEMU)
+- [ ] `just clippy` — run clippy with `--deny warnings`
+- [ ] `just fmt` — run `cargo fmt` (reformats in place, for local use)
+- [ ] `just fmt-check` — run `cargo fmt --check` (CI mode — exits non-zero if formatting differs)
+- [ ] `just check` — fmt-check + clippy + build (CI shortcut; does not require QEMU)
+- [ ] `just clean` — cargo clean
+
+**Acceptance:** `just build`, `just clippy`, `just fmt-check`, and `just test` all pass with zero warnings. `just check` passes on a clean checkout without QEMU installed.
+
+-----
+
+### Step 6: QEMU Runner Configuration
+
+**What:** Configure QEMU aarch64 with the virt machine so `just run` launches the kernel.
+
+**Prerequisites:** QEMU 6.0+ (`qemu-system-aarch64`). Phase 1 UEFI boot will additionally require QEMU 7.0+ and the `edk2-aarch64` firmware package — install both now to avoid retrofitting CI later.
+
+**Tasks:**
+- [ ] QEMU invocation: `qemu-system-aarch64 -machine virt -cpu cortex-a72 -smp 4 -m 2G -nographic -serial stdio -kernel <kernel-elf>`
+  - `-cpu cortex-a72` matches the Raspberry Pi 4 target hardware
+  - `-smp 4` emulates 4 cores so the secondary core parking code from Step 3 is exercised
+  - `-serial stdio` explicitly routes the PL011 UART to the terminal. `-nographic` implies `-serial mon:stdio` on most QEMU versions, but the behavior varies — explicit `-serial stdio` avoids silent failures where UART output never appears
+  - On macOS with Apple Silicon, `-accel hvf` can be added for host-accelerated execution (optional for Phase 0)
+- [ ] Use `-kernel` with the ELF directly — no `objcopy` to flat binary needed. QEMU reads the ELF entry point from headers, and ELF preserves symbols for GDB debugging.
+- [ ] Wire into `just run` and `just debug` recipes from Step 5
+- [ ] Verify UART output appears in terminal
+
+**Acceptance:** `just run` builds the kernel and launches QEMU. "AIOS kernel booting..." appears in terminal. `Ctrl+A, X` exits QEMU cleanly. `just debug` starts QEMU paused and accepting GDB connections on port 1234.
+
+-----
+
+## Milestone 3 — Scaffold Complete (End of Week 2)
+
+*Goal: CI passes on clean checkout; panic prints to UART; VBAR_EL1 confirmed.*
+
+-----
+
+### Step 7: CI Pipeline (GitHub Actions)
+
+**What:** Set up CI that validates every push and PR.
+
+**Tasks:**
+- [ ] Create `.github/workflows/ci.yml`
+- [ ] Jobs: `check` (fmt-check + clippy), `build` (debug + release), `test` (host unit tests)
+- [ ] Cache Rust toolchain and cargo registry (use `Swatinem/rust-cache` or similar — the nightly toolchain with `rust-src` and `llvm-tools` is ~2 GB)
+- [ ] Install QEMU 7.0+ and `edk2-aarch64` firmware in CI (install now; QEMU integration tests are optional for Phase 0 but Phase 1 needs both immediately)
+- [ ] Add CI badge to `README.md`
+
+**Acceptance:** Push to GitHub triggers CI. All jobs pass on a clean checkout.
+
+-----
+
+### Step 8: Panic Handler and Boot Diagnostics
+
+**What:** Upgrade the stub panic handler to print to UART, define the Rust exception vector table, and print boot diagnostics.
+
+**Tasks:**
+- [ ] Upgrade `#[panic_handler]` from the Step 2 `loop {}` stub to print panic info (message, file, line) to UART, then halt (`loop { unsafe { core::arch::asm!("wfe") } }`)
+- [ ] Add `kernel/src/arch/aarch64/exceptions.rs` — define the full exception vector table (16 entries at 128-byte spacing, `.align 7` per entry in assembly, all entries branch-to-self for now; real handlers come in Phase 1). The section base alignment (`ALIGN(2048)` in the linker script, defined in Step 3) and per-entry alignment (`.align 7` here) are separate requirements — both must be present.
+- [ ] Reinstall `VBAR_EL1` from `kernel_main` pointing to the Rust-defined vector table. The boot.S stub from Step 3 is a temporary safety net for the window between entry and this point — any fault in that window causes a deterministic halt (branch-to-self), which is intentional. The boot.S stub is removed when Phase 1 installs real exception handlers.
+- [ ] Print boot diagnostics to UART: current EL (confirm it is 1), core ID from `MPIDR_EL1`, `VBAR_EL1` value (confirm it matches the vector table symbol address from `cargo objdump`)
+
+**Acceptance:** A `panic!("test")` in `kernel_main` prints the panic message and file:line to UART, then halts. UART shows current EL = 1 and core ID = 0. `VBAR_EL1` printed value matches the vector table symbol from objdump.
+
+-----
+
+## Decision Points
+
+| Decision | Options | Recommendation |
+|---|---|---|
+| Boot method for Phase 0 | UEFI stub vs. ELF loaded by `-kernel` | ELF via `-kernel`. UEFI stub is Phase 1 work. QEMU loads the ELF at the physical address from its ELF headers, drops to EL1, and passes a DTB pointer in x0. |
+| Kernel load address | `0x4008_0000` (512 KiB offset) vs. `0x4010_0000` (1 MiB offset) | `0x4008_0000`. The 512 KiB offset leaves room for QEMU's DTB near RAM base (`0x4000_0000`). The Phase 0 kernel is tiny. Move to `0x4010_0000` if DTB overlap is observed. |
+| Linker script wiring | `.cargo/config.toml` hardcoded `-T` vs. `build.rs` | `build.rs`. The config.toml path is relative to the workspace root and silently breaks when building from subdirectories. `build.rs` with `cargo:rustc-link-arg` is path-safe and idiomatic. |
+| UART approach | Hardcoded MMIO vs. HAL trait | Hardcoded for Phase 0. The HAL `Platform` trait and `detect_platform()` are Phase 1 work. Keep it simple now, refactor later. |
+| Test strategy | Host-only unit tests vs. QEMU integration tests | Host-only for Phase 0. QEMU integration tests (boot → check UART output) in Phase 1. |
+
+-----
+
+## Phase Completion Criteria
+
+All three milestones complete:
+
+- [ ] **M1** — `cargo build` produces an aarch64 ELF with zero warnings; `shared/` compiles for both bare-metal and host targets
+- [ ] **M2** — `just run` boots in QEMU and prints "AIOS kernel booting..." to UART; `just check` passes without QEMU installed
+- [ ] **M3** — CI pipeline passes on clean checkout; panic handler prints to UART; boot diagnostics confirm EL = 1, core ID = 0, VBAR_EL1 matches vector table symbol
+- [ ] Project has LICENSE (BSD-2-Clause), README (with QEMU 6.0+ prerequisite), .gitignore
+- [ ] Adding a new crate to workspace `[members]` and running `cargo build --workspace` succeeds without restructuring

--- a/docs/phases/01-boot-and-first-pixels.md
+++ b/docs/phases/01-boot-and-first-pixels.md
@@ -1,0 +1,301 @@
+# Phase 1: Boot and First Pixels
+
+**Tier:** 1 — Hardware Foundation
+**Duration:** 4 weeks
+**Deliverable:** UEFI stub boots kernel via edk2; kernel parses DTB, enables MMU, prints boot log; framebuffer shows coloured rectangle
+**Status:** Planned
+**Prerequisites:** Phase 0 (Foundation and Tooling)
+**Unlocks:** Phase 2 (Memory Management)
+
+-----
+
+## Objective
+
+Replace the Phase 0 QEMU `-kernel` shortcut with a real UEFI boot path. The UEFI stub assembles `BootInfo`, calls `ExitBootServices()`, and hands off to the kernel. The kernel then executes the full early-boot sequence: DTB parse, platform detection, interrupt controller, timer, MMU, buddy allocator, and heap. Phase 1 ends with the compositor writing a solid coloured rectangle to the UEFI framebuffer — the first visual output.
+
+By the end of this phase, booting QEMU with edk2 firmware and a VirtIO-Blk disk image shows the AIOS boot log on the serial console and a coloured rectangle on the virtual display.
+
+-----
+
+## Architecture References
+
+| Topic | Document | Relevant Sections |
+|---|---|---|
+| UEFI stub and BootInfo | [boot.md](../kernel/boot.md) | §2 Firmware Handoff (full); §2.1 UEFI Boot on aarch64; §2.2 BootInfo struct; §2.4 ESP layout |
+| Kernel early boot steps 1–9 | [boot.md](../kernel/boot.md) | §3.3 Steps 1–9 (entry through heap); §3.1 EarlyBootPhase enum; §3.2 KernelState struct |
+| SMP secondary core bringup | [boot.md](../kernel/boot.md) | §3.5 SMP Boot |
+| Platform trait and detection | [hal.md](../kernel/hal.md) | §2 Platform Detection; §3 Platform Trait; §3.2 Initialization Order |
+| PL011 UART (full init) | [hal.md](../kernel/hal.md) | §4.3 Uart (PL011 register offsets and init sequence) |
+| GICv3 interrupt controller | [hal.md](../kernel/hal.md) | §4.1 InterruptController (GICv3 distributor, redistributor, CPU interface) |
+| ARM Generic Timer | [hal.md](../kernel/hal.md) | §4.2 Timer (CNTFRQ_EL0, tick calculation, PPI wiring) |
+| MMU and page tables | [memory.md](../kernel/memory.md) | §3 Virtual Memory Manager; §3.1 Address Space Layout; §3.2 Page Tables |
+| Buddy allocator | [memory.md](../kernel/memory.md) | §2 Physical Memory Manager; §2.2 Buddy Allocator |
+| Slab/heap | [memory.md](../kernel/memory.md) | §4 Kernel Heap; §4.1 Slab Allocator |
+| QEMU vs real hardware | [boot.md](../kernel/boot.md) | §2.5 QEMU Boot vs Real Hardware |
+| Exception level model | [boot.md](../kernel/boot.md) | §2.6 Exception Level Model |
+
+-----
+
+## Milestones
+
+Milestones are numbered continuously across all phases. Phase 0 used M1–M3; Phase 1 continues with M4–M6.
+
+| Milestone | Steps | Target | Observable result |
+|---|---|---|---|
+| **M4 — UEFI stub runs** | 1–2 | End of week 1 | QEMU with edk2 prints "AIOS UEFI stub: ExitBootServices OK" to serial |
+| **M5 — Kernel boots to heap** | 3–6 | End of week 2 | Boot log shows all EarlyBootPhase transitions through HeapReady |
+| **M6 — First pixels** | 7–8 | End of week 4 | Coloured rectangle visible on QEMU virtual display; CI passes |
+
+-----
+
+## Milestone 4 — UEFI Stub Runs (End of Week 1)
+
+*Goal: QEMU boots via edk2 and the UEFI stub successfully exits Boot Services and jumps to the kernel.*
+
+-----
+
+### Step 1: UEFI Stub Crate and ESP Layout
+
+**What:** Create the `uefi-stub/` crate — a UEFI application that runs under edk2 Boot Services, assembles `BootInfo`, and jumps to the kernel.
+
+**Tasks:**
+- [ ] Create `uefi-stub/` crate with `#![no_std]`, `#![no_main]`. Target: `aarch64-unknown-uefi` (produces a PE/COFF `.efi` binary — different from the kernel's `aarch64-unknown-none` ELF)
+- [ ] Add `uefi` crate dependency (provides `SystemTable`, `BootServices`, `RuntimeServices`, `MemoryMap` wrappers). Pin a specific version.
+- [ ] Add `uefi-stub` to the workspace `Cargo.toml` members
+- [ ] Implement the UEFI entry point (`efi_main`): open `EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL` and print a banner to confirm the stub is reached
+- [ ] Implement ESP layout from boot.md §2.4: stub at `/EFI/AIOS/BOOTAA64.EFI`, kernel at `/EFI/AIOS/aios.elf`, config at `/EFI/AIOS/boot.cfg`
+- [ ] Add `just disk` recipe: creates a FAT32 disk image with the ESP, places stub and kernel ELF at the correct paths (requires `mformat` + `mcopy` from `mtools`, or equivalent)
+- [ ] Update `just run` to use edk2 firmware: `-bios /usr/share/qemu/OVMF.fd` (or `edk2-aarch64-code.fd` — package name varies by distro) and `-drive` instead of `-kernel`
+
+**QEMU invocation change:** Phase 0 used `qemu-system-aarch64 -kernel <elf>`. Phase 1 switches to:
+```
+qemu-system-aarch64 \
+  -machine virt \
+  -cpu cortex-a72 \
+  -smp 4 \
+  -m 2G \
+  -nographic \
+  -serial stdio \
+  -bios /path/to/edk2-aarch64-code.fd \
+  -drive if=none,id=disk0,file=aios.img,format=raw \
+  -device virtio-blk-pci,drive=disk0
+```
+
+**Note:** `aarch64-unknown-uefi` produces a PE/COFF binary. This is not the same as `aarch64-unknown-none`. The stub and the kernel are separate Rust crates with different targets. Add `aarch64-unknown-uefi` to `rust-toolchain.toml`'s `targets` list alongside `aarch64-unknown-none`.
+
+**Acceptance:** `just disk && just run` launches QEMU with edk2 firmware. The serial console shows the edk2 boot menu, then "AIOS UEFI stub" printed by the stub entry point.
+
+-----
+
+### Step 2: BootInfo Assembly and ExitBootServices
+
+**What:** Implement the full BootInfo assembly sequence from boot.md §2.1–2.2: parse the UEFI memory map, acquire GOP framebuffer, acquire DTB, exit Boot Services, and jump to the kernel.
+
+**Tasks:**
+- [ ] Implement memory map acquisition: call `BootServices.get_memory_map()`, iterate over `MemoryDescriptor` entries, build the `BootInfo.memory_map` (boot.md §2.2). Store in a region allocated with `BootServices.allocate_pool(MemoryType::BootServicesData, ...)` — this region must be included in the memory map as type `BootInfo` so the buddy allocator excludes it from the free pool (the kernel reads it before reclaiming)
+- [ ] Implement GOP framebuffer acquisition: open `EFI_GRAPHICS_OUTPUT_PROTOCOL`, read `Mode.Info` for width/height/stride/format, fill `BootInfo.framebuffer` (boot.md §2.2 `FramebufferInfo`). `PixelFormat` mapping: `PixelRedGreenBlueReserved8BitPerColor` → `Rgb8`; `PixelBlueGreenRedReserved8BitPerColor` → `Bgr8`; `PixelBitMask` → `Bitmask { red, green, blue }` (read the per-channel bitmask fields from `EFI_PIXEL_BITMASK` and store them — fill_rect in Step 8 must decode them at draw time). Store framebuffer base as a `PhysicalAddress`.
+- [ ] Implement DTB location: QEMU passes the DTB address via the UEFI `EFI_DTB_TABLE_GUID` configuration table entry. Retrieve with `SystemTable.config_table()`. Fill `BootInfo.device_tree` with base and size.
+- [ ] Set `BootInfo.magic` = `0x41494F53_424F4F54` (`"AIOSBOOT"` as a u64)
+- [ ] Fill `BootInfo.rng_seed` from `EFI_RNG_PROTOCOL` if available; zero-fill if not (kernel falls back to timer entropy)
+- [ ] Fill `BootInfo.kernel_phys_base` and `BootInfo.kernel_size` from the ELF load address and image size
+- [ ] Call `BootServices.exit_boot_services()`. After this call, no UEFI services are available — no allocation, no output, no nothing. The stub must not call any UEFI function after this point.
+- [ ] Jump to kernel entry point (`kernel_main`) passing `BootInfo` pointer in `x0` (per the Phase 1 ABI replacing the Phase 0 DTB pointer)
+- [ ] Update `kernel_main` signature and `shared/BootInfo` to accept the real pointer (replace Phase 0's `Option<u64>` stubs with `#[cfg(target_arch = "aarch64")]`-scoped real types where needed)
+
+**BootInfo pointer ABI:** The stub writes `BootInfo` into a page-aligned buffer, then jumps to the kernel with `x0` = physical address of that buffer. The kernel entry assembly (boot.S from Phase 0) must now save `x0` into `x19` (callee-saved) immediately — the Phase 1 boot assembly differs from Phase 0 here. `BootInfo` stays valid until the kernel records its contents; the memory map entry of type `BootInfo` tells the buddy allocator not to reclaim that page.
+
+**Acceptance:** Serial console shows "AIOS UEFI stub: ExitBootServices OK, jumping to kernel at 0x...". The kernel entry point is reached (confirmed by the Phase 0 UART print "AIOS kernel booting..." now appearing via the UEFI path).
+
+-----
+
+## Milestone 5 — Kernel Boots to Heap (End of Week 2)
+
+*Goal: Boot log shows all EarlyBootPhase transitions through HeapReady.*
+
+-----
+
+### Step 3: DTB Parse and Platform Detection
+
+**What:** Implement a minimal flattened device tree (FDT) parser sufficient to complete early boot. Full DTB parsing is not needed — only the nodes the kernel queries during Steps 3–6.
+
+**Tasks:**
+- [ ] Add `fdt` crate (or implement a minimal parser) — must be `no_std` compatible. The parser needs: root `compatible` string, `/chosen/stdout-path`, CPU nodes (for SMP count and MPIDR values), `/psci` node (conduit and `cpu_on` function ID), memory nodes (base and size for each RAM region), GICv3 distributor and redistributor base addresses, ARM Generic Timer interrupt numbers
+- [ ] Implement `detect_platform(dt: &DeviceTree) -> Box<dyn Platform>` matching hal.md §2 (compatible string table) and §3 (Platform trait). For Phase 1 QEMU target: match `"qemu,virt"` compatible string → `QemuPlatform`
+- [ ] Implement `QemuPlatform` struct implementing the `Platform` trait skeleton (hal.md §3). Phase 1 only needs `init_uart`, `init_interrupts`, and `init_timer` — stub the remaining four with `unimplemented!()` for now
+- [ ] Advance `EarlyBootPhase` to `DeviceTreeParsed` and print to UART
+
+**Minimal parser scope:** The FDT parser only needs to find specific well-known nodes by path or compatible string. A full recursive traversal is Phase 4+ work (when the Device Registry service discovers all hardware). For now: parse only what Steps 3–6 require.
+
+**Acceptance:** Boot log shows `[boot] DeviceTreeParsed` with the detected platform name (`QemuPlatform`).
+
+-----
+
+### Step 4: Full PL011 UART Initialization
+
+**What:** Replace the Phase 0 hardcoded UART (relying on QEMU pre-initialization) with a proper PL011 driver that initializes from the DTB base address and programs baud rate registers. This is the `Platform::init_uart()` implementation.
+
+**Tasks:**
+- [ ] Read PL011 base address from DTB `/chosen/stdout-path` → resolve to MMIO node → extract `reg` property
+- [ ] Implement full PL011 initialization sequence (required on real hardware; harmless on QEMU):
+  1. Disable UART: clear CR.UARTEN (bit 0)
+  2. Wait for any in-progress transmission to finish: poll UARTFR.BUSY (bit 3)
+  3. Flush the FIFO: clear LCR_H.FEN (bit 4)
+  4. Program baud rate: `IBRD` = `clock_hz / (16 * baud_rate)`, `FBRD` = `round((clock_hz % (16 * baud_rate)) * 64 / (16 * baud_rate))`. QEMU PL011 UART clock: 24 MHz (this is the APB/UART peripheral clock — distinct from the ARM Generic Timer frequency of 62.5 MHz). For 115200 baud: IBRD=13, FBRD=1.
+  5. Set line control: LCR_H = 0x70 (8-bit, 1 stop, no parity, FIFO enabled)
+  6. Re-enable UART: CR = 0x301 (UARTEN | TXE | RXE)
+- [ ] Return `Uart` handle from `QemuPlatform::init_uart()`, store in `KernelState.uart`
+- [ ] Advance `EarlyBootPhase` to `UartReady` and print the first full boot banner
+
+**Register offsets (hal.md §4.3):**
+- `UARTDR` 0x000 — data register
+- `UARTFR` 0x018 — flag register (TXFF bit 5, BUSY bit 3, RXFE bit 4)
+- `UARTIBRD` 0x024 — integer baud rate divisor
+- `UARTFBRD` 0x028 — fractional baud rate divisor
+- `UARTLCR_H` 0x02C — line control
+- `UARTCR` 0x030 — control register
+
+**Acceptance:** Boot log shows `[boot] UartReady — Xms` with the correct baud rate configuration. Serial output continues to work on a fresh QEMU launch (not relying on QEMU pre-init state).
+
+-----
+
+### Step 5: Interrupt Controller (GICv3) and Timer
+
+**What:** Initialize the GICv3 interrupt controller and ARM Generic Timer so the kernel has a working 1 ms scheduler tick before the MMU is enabled.
+
+**Tasks:**
+
+**GICv3 (hal.md §4.1):**
+- [ ] Read GICv3 distributor base (`GICD`) and redistributor base (`GICR`) from DTB. On QEMU virt: `GICD` at `0x0800_0000`, `GICR` at `0x080A_0000` (8 redistributor frames × 128 KiB each for 4 cores)
+- [ ] Initialize distributor: set `GICD_CTLR.ARE_NS` (affinity routing enable), enable Group 1 non-secure interrupts
+- [ ] Initialize per-CPU redistributor: wake redistributor (clear `GICR_WAKER.ProcessorSleep`, wait for `ChildrenAsleep` to clear), enable Group 1 SGIs
+- [ ] Enable CPU interface via system registers: `ICC_SRE_EL1 |= 1` (enable system register interface), `ICC_IGRPEN1_EL1 = 1` (enable Group 1), set `ICC_PMR_EL1 = 0xFF` (allow all priorities)
+- [ ] Store `InterruptController` handle in `KernelState.interrupt_controller`
+- [ ] Advance `EarlyBootPhase` to `InterruptsReady`
+
+**ARM Generic Timer (hal.md §4.2):**
+- [ ] Read `CNTFRQ_EL0` for the timer frequency. QEMU virt default: 62.5 MHz
+- [ ] Calculate the 1 ms tick count: `tick_count = freq_hz / 1000`
+- [ ] Program `CNTP_TVAL_EL0 = tick_count` (physical timer compare value)
+- [ ] Enable physical timer: `CNTP_CTL_EL0 = 0x1` (ENABLE bit)
+- [ ] Register the timer interrupt in the GIC (PPI interrupt 30, `INTID = 30`)
+- [ ] Store `Timer` handle in `KernelState.timer`
+- [ ] Advance `EarlyBootPhase` to `TimerReady`
+
+**Note:** Interrupts are enabled in the GIC but not yet globally enabled in PSTATE (`DAIF.I` bit). The scheduler will unmask interrupts after the MMU is up and the first process context is ready (Phase 3). The timer interrupt fires but is masked at PSTATE level until then.
+
+**Acceptance:** Boot log shows `[boot] InterruptsReady` and `[boot] TimerReady — Xms`. GICv3 distributor and redistributor are configured without hanging. `CNTFRQ_EL0` value is printed and matches 62.5 MHz (62500000 Hz) on QEMU.
+
+-----
+
+### Step 6: MMU Enable and Buddy Allocator
+
+**What:** Build kernel page tables, enable the MMU, switch to virtual addresses, and initialize the buddy allocator. After this step, the kernel runs at high-half virtual addresses (`0xFFFF_...`).
+
+**Tasks:**
+
+**Page table setup (memory.md §3):**
+- [ ] Allocate page table memory from the raw physical memory free list (before the buddy allocator exists — use a simple bump allocator backed by a statically-sized buffer, e.g. 64 KiB, for the initial page tables only)
+- [ ] Build TTBR1_EL1 kernel mappings per boot.md §3.3 Step 7:
+  - `0xFFFF_0000_0000_0000` — kernel text (PXN=0, UXN=1, AP=RO), rodata (PXN=1, UXN=1, AP=RO), data/bss (PXN=1, UXN=1, AP=RW)
+  - `0xFFFF_0000_4000_0000` — kernel heap region (reserved, not yet mapped)
+  - `0xFFFF_0001_0000_0000` — physical memory direct map (all RAM, device memory)
+  - `0xFFFF_0002_0000_0000` — MMIO (device memory, `nGnRnE` attribute)
+- [ ] Keep TTBR0_EL1 identity map active during the transition
+- [ ] Configure `MAIR_EL1` with memory attribute indices: index 0 = `nGnRnE` (device), index 1 = Normal writeback cacheable (RAM)
+- [ ] Configure `TCR_EL1`: T1SZ=16 (48-bit VA), TG1=4KiB granule, SH1=inner-shareable, ORGN1/IRGN1=writeback cacheable
+- [ ] Enable MMU: set `SCTLR_EL1.M`, `SCTLR_EL1.C` (D-cache), `SCTLR_EL1.I` (I-cache). Issue `ISB` after write.
+- [ ] Switch the stack pointer to the new virtual address (TTBR1 high-half stack region)
+- [ ] Remove TTBR0 identity mapping entries for kernel addresses (keep user address space range for future process mappings)
+- [ ] Advance `EarlyBootPhase` to `MmuEnabled`
+
+**Buddy allocator (memory.md §2.2):**
+- [ ] Walk the `BootInfo.memory_map` and add all `Conventional`, `LoaderCode`, `LoaderData`, `BootServicesCode`, `BootServicesData` pages to the buddy allocator free list. Exclude: kernel image pages, BootInfo page, initramfs pages, UEFI Runtime pages, MMIO regions.
+- [ ] Implement buddy allocator orders 0–10 (4 KiB to 4 MiB blocks)
+- [ ] Store in `KernelState.page_allocator`
+- [ ] Advance `EarlyBootPhase` to `PageAllocatorReady`
+
+**Kernel heap (memory.md §4.1):**
+- [ ] Initialize slab allocator on top of the buddy allocator. Named caches per memory.md §4.1: `ipc_message` (64 B), `capability_token` (128 B), `channel` (256 B), `process_descriptor` (512 B), `vm_region` (128 B), `page_table` (4096 B)
+- [ ] Register as `GlobalAlloc` so `Box`, `Vec`, `String` work
+- [ ] Store in `KernelState.heap`
+- [ ] Advance `EarlyBootPhase` to `HeapReady`
+
+**W^X enforcement:** Every page mapped into TTBR1 must be either writable or executable, never both. Kernel text: executable, read-only. Kernel data/bss: writable, non-executable. This is enforced at mapping time and verified by objdump in the acceptance criteria.
+
+**Cache maintenance (boot.md §3.3 Step 7 note):** After enabling the new TTBR1 mapping: issue `IC IALLU; ISB` to invalidate the instruction cache and ensure no stale entries from the pre-MMU physical addresses survive.
+
+**Acceptance:** Boot log shows `[boot] MmuEnabled`, `[boot] PageAllocatorReady`, `[boot] HeapReady — Xms`. `Box::new(42u32)` succeeds (heap is live). `cargo objdump` shows kernel text at `0xFFFF_0000_0000_xxxx` (high-half) after relinking for the virtual address. No UART output interruption during the MMU transition.
+
+-----
+
+## Milestone 6 — First Pixels (End of Week 4)
+
+*Goal: Coloured rectangle visible on QEMU virtual display; CI passes.*
+
+-----
+
+### Step 7: SMP Secondary Core Bringup
+
+**What:** Bring secondary cores (1–3) online via PSCI after the scheduler is minimally initialised. Secondary cores are parked in `wfe` loops from Phase 0; this step wakes them.
+
+**Tasks:**
+- [ ] Implement minimal `Scheduler` stub: enough to allocate per-core kernel stacks and track which cores are online. Full scheduling classes (RT, Interactive, Normal, Idle) are Phase 3 work.
+- [ ] Read PSCI conduit from DTB `/psci` node: `method = "hvc"` on QEMU (QEMU without KVM emulates PSCI at the hypervisor level)
+- [ ] For each secondary CPU node in the DTB (cores 1–3):
+  - Allocate a 16 KiB kernel stack with guard page at `0xFFFF_0000_8000_0000 + core_id * 0x10000`
+  - Call `PSCI CPU_ON` (function ID `0xC400_0003` for 64-bit PSCI) via `HVC` with: `target_cpu` = MPIDR value from DTB, `entry_point_address` = physical address of the secondary entry point in boot.S, `context_id` = core index
+- [ ] Implement secondary core entry in `boot.S`: FPU enable, VBAR_EL1 install (same vectors as boot CPU), load the allocated stack pointer, call `secondary_main(core_id: usize)`
+- [ ] `secondary_main`: print `[boot] Core N online`, advance per-core `EarlyBootPhase`, then enter the idle loop (`wfe`) until the scheduler assigns work
+- [ ] Advance boot CPU `EarlyBootPhase` to `ProcessManagerReady` once all secondaries check in
+
+**PSCI function IDs (64-bit SMCCC):**
+- `CPU_ON`: `0xC400_0003`
+- `SYSTEM_RESET`: `0x8400_0009`
+- `SYSTEM_OFF`: `0x8400_0008`
+
+**Acceptance:** Boot log shows `[boot] Core 1 online`, `[boot] Core 2 online`, `[boot] Core 3 online` before the first-pixels step. All 4 cores are running at EL1 with their own stacks and the shared TTBR1 page tables.
+
+-----
+
+### Step 8: Framebuffer and First Pixels
+
+**What:** Write directly to the GOP framebuffer passed in `BootInfo` to render a coloured rectangle — the first visual output of the OS. This validates the framebuffer address, pixel format detection, and stride calculation.
+
+**Tasks:**
+- [ ] Read `BootInfo.framebuffer`: base address, width, height, stride, pixel format
+- [ ] Map the framebuffer physical address into the kernel's MMIO virtual address range (`0xFFFF_0002_...`), mapped as device memory (`nGnRnE`)
+- [ ] Implement `fill_rect(fb: &FramebufferInfo, x: u32, y: u32, w: u32, h: u32, r: u8, g: u8, b: u8)` — writes pixel data respecting stride and pixel format:
+  - `Bgr8`: write bytes in order `[b, g, r, 0xFF]` (4 bytes per pixel)
+  - `Rgb8`: write bytes in order `[r, g, b, 0xFF]` (4 bytes per pixel)
+- [ ] Render: black background (fill entire framebuffer with zeros), then a centred rectangle in AIOS brand colour (e.g. 60% width × 60% height, RGB `#5B8CFF` or similar)
+- [ ] Print to UART: `[boot] Framebuffer: WxH stride=S format=Bgr8/Rgb8 at 0x...`
+- [ ] Update CI: add a QEMU headless screenshot step using `-display none -device virtio-gpu-pci` with `virtio-gpu` screendump via QEMU monitor, or skip framebuffer CI test (UART output is sufficient for CI; framebuffer is verified manually)
+
+**Framebuffer layout note:** The UEFI GOP framebuffer on QEMU virt is typically `800×600` or `1024×768` depending on the edk2 version. `stride` is the **byte offset** from the start of one row to the start of the next — it is already in bytes, not pixels, and may include padding. Always compute pixel byte offset as `y * stride + x * 4` (for 32-bit formats), not `y * width * 4`. Using `width * 4` when stride > width will produce a diagonal smear.
+
+**Acceptance:** QEMU virtual display (viewed via VNC or SDL — add `-display gtk` to see it) shows a solid coloured rectangle on a black background. UART shows the framebuffer diagnostics line. CI passes without the framebuffer check (UART-only CI is acceptable).
+
+-----
+
+## Decision Points
+
+| Decision | Options | Recommendation |
+|---|---|---|
+| FDT parser | Implement minimal parser vs. use `fdt` crate | Use the `fdt` crate (MIT licensed, `no_std` compatible). A hand-rolled parser adds risk. Only implement a custom parser if crate licensing or `no_std` compatibility is a problem. |
+| UEFI crate | `uefi` crate vs. raw UEFI ABI | Use the `uefi` crate for Phase 1 — it provides safe wrappers for `BootServices`, `RuntimeServices`, and `GOP`. The raw ABI is an option if the crate becomes a problem, but it is not needed yet. |
+| edk2 firmware source | System package vs. built from source | Use the system package (`qemu-efi-aarch64` on Debian/Ubuntu, `edk2-aarch64` on Fedora, or download from https://retrage.github.io/edk2-nightly/). Building edk2 from source is not needed for Phase 1. |
+| MMU transition approach | Enable MMU in assembly vs. Rust | Enable in assembly (boot.S). The MMU enable instruction (`msr SCTLR_EL1, x`) must be at a physical address valid in both the old identity map and the new TTBR1 map simultaneously. This is easier to arrange in assembly where you control exact instruction placement. |
+| Framebuffer CI | Screenshot in CI vs. manual verify | Skip framebuffer screenshot in CI for Phase 1 — UART output is deterministic and sufficient. Framebuffer regression testing comes with the compositor (Phase 6). |
+
+-----
+
+## Phase Completion Criteria
+
+All three milestones complete:
+
+- [ ] **M4** — QEMU boots via edk2; stub prints banner and exits Boot Services; kernel entry is reached
+- [ ] **M5** — Boot log shows `UartReady`, `DeviceTreeParsed`, `InterruptsReady`, `TimerReady`, `MmuEnabled`, `PageAllocatorReady`, `HeapReady`; `Box::new(42u32)` succeeds; `just check` passes
+- [ ] **M6** — All 4 cores online; coloured rectangle visible on QEMU virtual display; CI passes on clean checkout
+- [ ] `BootInfo.magic` is validated at kernel entry; mismatched magic halts with a UART error message
+- [ ] W^X enforced: `cargo objdump` shows no page is both writable and executable
+- [ ] `just disk` reproducibly builds the ESP image; `just run` boots end-to-end without manual steps

--- a/docs/project/development-plan.md
+++ b/docs/project/development-plan.md
@@ -208,42 +208,38 @@ All permissively licensed. No GPL dependencies in the core OS.
 
 ## 8. Phase Detail Reference
 
-Each phase's detailed technical design and step-by-step implementation guide lives in its own directory:
+Each phase has an implementation doc in `docs/phases/` containing objectives, milestone steps with acceptance criteria, decision points, and references to the existing architecture documents (which hold the technical design). This avoids duplicating architecture content while providing a clear implementation sequence.
 
-| Phase | Directory | Status |
-|---|---|---|
-| 0 | `00 - Foundation and Tooling/` | Planned |
-| 1 | `01 - Boot and First Pixels/` | Planned |
-| 2 | `02 - Memory Management/` | Planned |
-| 3 | `03 - IPC and Capability System/` | Planned |
-| 4 | `04 - Block Storage and Object Store/` | Planned |
-| 5 | `05 - GPU and Display/` | Planned |
-| 6 | `06 - Window Compositor and Shell/` | Planned |
-| 7 | `07 - Input Terminal and Basic Networking/` | Planned |
-| 8 | `08 - AIRS Core/` | Planned |
-| 9 | `09 - Space Intelligence and Conversation/` | Planned |
-| 10 | `10 - Agent Framework/` | Planned |
-| 11 | `11 - Tasks Flow and Attention/` | Planned |
-| 12 | `12 - Developer Experience and SDK/` | Planned |
-| 13 | `13 - Security Hardening/` | Planned |
-| 14 | `14 - Performance and Optimization/` | Planned |
-| 15 | `15 - POSIX Compatibility and BSD Userland/` | Planned |
-| 16 | `16 - Network Translation Module/` | Planned |
-| 17 | `17 - USB Stack and Hotplug/` | Planned |
-| 18 | `18 - WiFi Bluetooth and Wireless/` | Planned |
-| 19 | `19 - Power Management and Thermal/` | Planned |
-| 20 | `20 - Portable UI Toolkit/` | Planned |
-| 21 | `21 - Web Browser/` | Planned |
-| 22 | `22 - Media Audio and Camera/` | Planned |
-| 23 | `23 - Accessibility and Internationalization/` | Planned |
-| 24 | `24 - Secure Boot and Update System/` | Planned |
-| 25 | `25 - Linux Binary and Wayland Compatibility/` | Planned |
-| 26 | `26 - Enterprise and Multi-Device/` | Planned |
-| 27 | `27 - Real Hardware Certification and Launch/` | Planned |
-
-Each directory will contain:
-- `phase-detail.md` — Technical design, architecture decisions, data models, interfaces
-- `milestone-steps.md` — Step-by-step implementation with acceptance criteria and tests
+| Phase | Name | Document | Status |
+|---|---|---|---|
+| 0 | Foundation & Tooling | [`00-foundation-and-tooling.md`](../phases/00-foundation-and-tooling.md) | Planned |
+| 1 | Boot & First Pixels | `01-boot-and-first-pixels.md` | Planned |
+| 2 | Memory Management | `02-memory-management.md` | Planned |
+| 3 | IPC & Capability System | `03-ipc-and-capability-system.md` | Planned |
+| 4 | Block Storage & Object Store | `04-block-storage-and-object-store.md` | Planned |
+| 5 | GPU & Display | `05-gpu-and-display.md` | Planned |
+| 6 | Window Compositor & Shell | `06-window-compositor-and-shell.md` | Planned |
+| 7 | Input, Terminal & Basic Networking | `07-input-terminal-and-basic-networking.md` | Planned |
+| 8 | AIRS Core | `08-airs-core.md` | Planned |
+| 9 | Space Intelligence & Conversation | `09-space-intelligence-and-conversation.md` | Planned |
+| 10 | Agent Framework | `10-agent-framework.md` | Planned |
+| 11 | Tasks, Flow & Attention | `11-tasks-flow-and-attention.md` | Planned |
+| 12 | Developer Experience & SDK | `12-developer-experience-and-sdk.md` | Planned |
+| 13 | Security Hardening | `13-security-hardening.md` | Planned |
+| 14 | Performance & Optimization | `14-performance-and-optimization.md` | Planned |
+| 15 | POSIX Compatibility & BSD Userland | `15-posix-compatibility-and-bsd-userland.md` | Planned |
+| 16 | Network Translation Module | `16-network-translation-module.md` | Planned |
+| 17 | USB Stack & Hotplug | `17-usb-stack-and-hotplug.md` | Planned |
+| 18 | WiFi, Bluetooth & Wireless | `18-wifi-bluetooth-and-wireless.md` | Planned |
+| 19 | Power Management & Thermal | `19-power-management-and-thermal.md` | Planned |
+| 20 | Portable UI Toolkit | `20-portable-ui-toolkit.md` | Planned |
+| 21 | Web Browser | `21-web-browser.md` | Planned |
+| 22 | Media, Audio & Camera | `22-media-audio-and-camera.md` | Planned |
+| 23 | Accessibility & Internationalization | `23-accessibility-and-internationalization.md` | Planned |
+| 24 | Secure Boot & Update System | `24-secure-boot-and-update-system.md` | Planned |
+| 25 | Linux Binary & Wayland Compatibility | `25-linux-binary-and-wayland-compatibility.md` | Planned |
+| 26 | Enterprise & Multi-Device | `26-enterprise-and-multi-device.md` | Planned |
+| 27 | Real Hardware, Certification & Launch | `27-real-hardware-certification-and-launch.md` | Planned |
 
 -----
 

--- a/docs/project/overview.md
+++ b/docs/project/overview.md
@@ -440,13 +440,17 @@ docs/
 │   ├── browser.md                    Decomposed web browser
 │   └── ui-toolkit.md                 Portable UI toolkit
 │
-└── security/
-    └── security.md                   Security architecture
+├── security/
+│   └── security.md                   Security architecture
+│
+└── phases/                           Implementation milestones per phase
+    ├── 00-foundation-and-tooling.md  Phase 0: project scaffold, CI, build
+    └── ...                           (28 phases total, created as work begins)
 ```
 
-### Phase Detail Documents (planned)
+### Phase Implementation Documents
 
-Each development phase will have companion `phase-detail.md` and `milestone-steps.md` documents (see [development-plan.md](./development-plan.md) for phase list).
+Each phase has a single implementation doc in `docs/phases/` with milestone steps, acceptance criteria, and references to architecture docs. Architecture lives in the domain directories above; phase docs define the build sequence. See [development-plan.md](./development-plan.md) §8 for the full list.
 ---
 ## 12. Related Architecture Documents
 These companion documents provide deep-dive technical specifications:


### PR DESCRIPTION
## Summary

- Add `docs/phases/00-foundation-and-tooling.md` — Phase 0 implementation doc covering toolchain setup, workspace scaffold, QEMU direct-kernel boot, and CI. Stable after 6 audit passes.
- Add `docs/phases/01-boot-and-first-pixels.md` — Phase 1 implementation doc covering UEFI stub, BootInfo handoff, DTB parse, PL011 full init, GICv3 + Generic Timer, MMU enable + buddy allocator, SMP bringup, and GOP framebuffer first pixels. Stable after 4 audit passes.
- Update `docs/project/development-plan.md` §8 phase table with flat file references and Name column.
- Update `docs/project/overview.md` §11 document index with `docs/phases/` directory.

Milestones are numbered continuously across phases: M1–M3 (Phase 0), M4–M6 (Phase 1).

## Test plan

- [ ] All architecture section references resolve correctly (hal.md §4.1/4.2/4.3, boot.md §2–3.5, memory.md §2–4)
- [ ] Milestone numbering is continuous (M1–M3 → M4–M6)
- [ ] QEMU invocation uses `-serial stdio` and `-gdb tcp::1234`
- [ ] No EL2 drop step present in Phase 0
- [ ] `llvm-tools` (not `llvm-tools-preview`) throughout
- [ ] Phase 1 FPU enable uses `x1` scratch register, saved `x0` into `x19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)