### PR TITLE
Add /write-arch-doc skill for architecture document lifecycle

### DIFF
--- a/.claude/skills/write-arch-doc/SKILL.md
+++ b/.claude/skills/write-arch-doc/SKILL.md
@@ -53,9 +53,11 @@ Present proposed scope summary. Iterate until user approves.
 
 Create an isolated worktree for this work:
 
-1. Run: `git worktree add .claude/worktrees/docs-$TOPIC -b claude/docs-$TOPIC main`
-   - Where `$TOPIC` is derived from `$ARGUMENTS` (e.g., `networking`, `memory`)
-2. All subsequent file operations happen in the worktree path
+1. Derive a sanitized `$TOPIC` slug from `$ARGUMENTS` for safe use in paths and branch names:
+   - Lowercase, replace spaces/slashes/non-alphanumeric with `-`, trim leading/trailing `-`
+   - Restrict to `[a-z0-9-]` (e.g., `docs/kernel/memory.md` → `memory`, `Shared Memory` → `shared-memory`)
+2. Run: `git worktree add .claude/worktrees/docs-$TOPIC -b claude/docs-update-$TOPIC main`
+3. All subsequent file operations happen in the worktree path
 
 ## Step 4: Outline / Change Plan (Interactive)
 
@@ -129,7 +131,7 @@ Write each major section, presenting to the user for review after each:
 1. Add or update the entry in CLAUDE.md Architecture Document Map
 2. Update any existing docs that should reference this new/updated doc
 3. Ensure phase docs that reference this subsystem have correct pointers
-4. Check `docs/project/developer-guide.md` cross-reference index
+4. If `docs/project/developer-guide.md` exists, check its cross-reference index
 
 ## Step 8: Audit Loop (Mandatory)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -535,7 +535,7 @@ Single team lead + specialist agents. Fully autonomous — human reviews async v
 | `/implement-phase N` | Phase implementation request | Full phase implementation workflow |
 | `/generate-phase-doc N` | Phase doc request | Generates phase doc from arch docs |
 | `/verify-phase N` | After implementation | Runs all quality gates |
-| `/write-arch-doc <topic>` | Architecture doc request | Interactive create/update architecture docs with research |
+| `/write-arch-doc <topic-or-path>` | Architecture doc request | Interactive create/update architecture docs with research |
 
 **Document Lifecycle**: All doc changes go to `claude/*` branches with PRs. Doc-auditor loops (audit → fix → re-audit) until zero issues, max 10 passes.
 


### PR DESCRIPTION
## Summary

- Adds `/write-arch-doc <topic>` skill — interactive, human-guided workflow for creating new architecture docs or updating existing ones
- 9-step workflow: discover → scope → worktree → outline → **research & improve** → write → cross-ref → audit → PR
- Research phase searches OS papers (OSDI/SOSP/USENIX) and production OSes (seL4, Fuchsia, Redox, Hubris) for improvements AIOS can adopt
- Dual mode: auto-detects CREATE vs MAINTAIN from arguments
- Mandatory doc-auditor loop before PR
- Updates CLAUDE.md Skills table and Workspace Layout

## Motivation

Architecture docs (`docs/kernel/*.md`, `docs/platform/*.md`, etc.) had no dedicated creation/maintenance workflow. The `doc-writer` only generates phase docs *from* architecture docs, and the `doc-auditor` only checks internal consistency. This skill fills the gap.

## Test plan

- [x] Invoke `/write-arch-doc` — verify skill loads and creates TodoWrite items
- [x] Verify AskUserQuestion is used for scope and outline stages
- [x] Verify research step uses WebSearch for external OS research
- [x] Verify doc-auditor is triggered at end of workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)