### PR TITLE
Docs: Update boot.md architecture doc

### DIFF
--- a/docs/kernel/boot.md
+++ b/docs/kernel/boot.md
@@ -555,7 +555,7 @@ Secondary core (_secondary_entry in boot.S → secondary_main in smp.rs):
   10. Enter scheduler (parks in wfe until SCHED_READY)
 ```
 
-**Critical: NC memory atomics.** The turn-based printing protocol uses only `load(Acquire)` / `store(Release)` — plain loads/stores with ordering, not exclusive pairs. This is safe on Non-Cacheable memory (Phase 1 identity map uses edk2 MAIR Attr1=0x44). `spin::Mutex` and `fetch_add` would hang. See `uart.rs` and `smp.rs` header comments.
+**Historical note: NC memory atomics.** The turn-based printing protocol uses only `load(Acquire)` / `store(Release)` — plain loads/stores with ordering, not exclusive pairs. This pattern was essential in Phase 1 when the identity map used Non-Cacheable memory (MAIR Attr1=0x44). Phase 2 M8 upgraded TTBR0 RAM blocks to Write-Back cacheable (MAIR Attr3=0xFF), making `spin::Mutex` and exclusive pairs safe. The conservative protocol remains as defense-in-depth — it works regardless of memory attributes.
 
 **Critical: IRQ deferral.** Secondary cores do NOT unmask IRQs in `secondary_main`. Timer tick handlers use `compare_exchange` (exclusive monitor), which can starve the boot CPU's spinlock acquisitions during init. IRQs are unmasked later in `enter_scheduler()` after `SCHED_READY` is set.
 


### PR DESCRIPTION
## Summary

- **§1.1 Boot Philosophy**: Added seL4/Zircon research-based design principles (minimum-kernel, maximum-delegation)
- **§2.2 BootInfo**: Fixed to show actual flat `u64` C ABI struct (was showing fictional `Option<T>` fields)
- **§2.6 Platform trait**: Now shows full future trait with Phase 2+ methods (`init_gpu`, `init_network`, `init_storage`, `init_rng`) and Pi 4/5 platform detection
- **§3.1-3.3**: Complete rewrite of kernel early boot sections to match actual `boot.S` + `kernel_main` code
- **§3.2 KernelState**: Replaced fictional centralized struct with actual per-subsystem globals table (5 naming fixes from doc-auditor)
- **§3.4-3.5**: Updated UART and SMP sections with actual two-phase init, NC memory atomics, IRQ deferral
- **§11 Future Directions**: New section with Hubris-style determinism, ZBI-style boot data, measured boot, boot intelligence
- Fixed all unfenced code blocks (markdown lint clean)

## Test plan

- [x] Doc-auditor: 2 passes, clean on pass 2 (5 fixes applied)
- [x] Cross-reference check: all internal §refs and external doc links verified
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)